### PR TITLE
Fix: Admin Panel View

### DIFF
--- a/plugins/pencilblue/services/localization/db_localizations.js
+++ b/plugins/pencilblue/services/localization/db_localizations.js
@@ -181,7 +181,7 @@ module.exports = function (pb) {
         var displayObj = {};
 
         displayObj.site = buildKVObject(siteLocs, localeObj, selectedPlugin);
-        displayObj.generic = buildKVObject(data.storage, localeObj, selectedPlugin);
+        displayObj.generic = buildKVObject(pb.Localization.storage, localeObj, selectedPlugin);
 
         return displayObj;
     }


### PR DESCRIPTION
Fixed "generic" keys list in the admin panel.  It now will show the default key/values from the files that are loaded.
